### PR TITLE
Copy Banner, NacelleButton components from Nacelle website to theme

### DIFF
--- a/components/Banner.vue
+++ b/components/Banner.vue
@@ -1,0 +1,135 @@
+<template>
+  <div class="banner">
+    <transition name="slide">
+      <div class="banner-container" v-if="open">
+        <p>{{ message }}</p>
+        <nacelle-button
+          class="nacelle-banner-button"
+          @click="goTo(buttonPath)"
+          color="secondary"
+          >{{ buttonText }}</nacelle-button
+        >
+        <img
+          @click="closeBanner"
+          class="close-banner"
+          src="/alertbar-x-icon.svg"
+        />
+      </div>
+    </transition>
+  </div>
+</template>
+
+<script>
+import NacelleButton from './NacelleButton.vue'
+export default {
+  components: {
+    NacelleButton
+  },
+  data() {
+    return {
+      open: false
+    }
+  },
+  props: {
+    title: {
+      type: String,
+      default: ''
+    },
+    buttonText: {
+      type: String,
+      default: ''
+    },
+    buttonPath: {
+      type: String,
+      default: ''
+    },
+    message: {
+      type: String,
+      default: ''
+    }
+  },
+  mounted() {
+    setTimeout(() => {
+      this.open = true
+    }, 1000)
+  },
+  methods: {
+    goTo(path) {
+      window.open(path, '_blank')
+    },
+    closeBanner() {
+      this.open = false
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.slide-enter-active,
+.slide-leave-active {
+  transition: transform 0.5s;
+}
+
+.slide-enter-to,
+.slide-leave {
+  transform: translateY(0px);
+}
+
+.slide-enter,
+.slide-leave-to {
+  transform: translateY(100px);
+}
+
+.banner-container {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100vw;
+  height: 80px;
+  background: #00baff;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 999;
+  p {
+    font-weight: 700;
+    text-align: center;
+    margin-right: 50px;
+    color: white;
+    font-family: "HK Grotesk";
+    font-size: 18px;
+    letter-spacing: .39px;
+    line-height: 26px;
+  }
+  .close-banner {
+    cursor: pointer;
+    height: 15px;
+    filter: brightness(0) invert(1);
+    position: absolute;
+    right: 40px;
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .banner-container {
+    flex-direction: column;
+    height: 110px;
+    // align-items: flex-start;
+
+    .nacelle-banner-button {
+      margin-left: 20px;
+    }
+    p {
+      margin: 0 20px 6px;
+      font-size: 16px;
+      letter-spacing: .25px;
+      line-height: 24px;
+      // text-align: left;
+    }
+    .close-banner {
+      right: 20px;
+      bottom: 20px;
+    }
+  }
+}
+</style>

--- a/components/Banner.vue
+++ b/components/Banner.vue
@@ -4,9 +4,10 @@
       <div class="banner-container" v-if="open">
         <p>{{ message }}</p>
         <nacelle-button
+          v-if="buttonPath"
           class="nacelle-banner-button"
-          @click="goTo(buttonPath)"
           color="secondary"
+          :button-path="buttonPath"
           >{{ buttonText }}</nacelle-button
         >
         <img
@@ -54,9 +55,6 @@ export default {
     }, 1000)
   },
   methods: {
-    goTo(path) {
-      window.open(path, '_blank')
-    },
     closeBanner() {
       this.open = false
     }

--- a/components/NacelleButton.vue
+++ b/components/NacelleButton.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="block ? 'block' : null" class="nacelle-button">
-    <button :class="color" @click="clickHandler()">
+    <a :class="color" :href="buttonPath" target="_blank">
       <span>
         <slot />
       </span>
@@ -8,7 +8,7 @@
         <div v-if="icon" v-html="icon" class="nacelle-button-icon"></div>
         <img v-else src="/nacelle-arrow-right.svg" alt="arrow-right" />
       </template>
-    </button>
+    </a>
   </div>
 </template>
 
@@ -67,10 +67,10 @@ export default {
     }
   }
 }
-button {
+a {
+  box-sizing: border-box;
   display: flex;
   align-items: center;
-  width: 100%;
   justify-content: space-between;
   text-decoration: none;
   border: 2px solid #00baff;

--- a/components/NacelleButton.vue
+++ b/components/NacelleButton.vue
@@ -1,0 +1,135 @@
+<template>
+  <div :class="block ? 'block' : null" class="nacelle-button">
+    <button :class="color" @click="clickHandler()">
+      <span>
+        <slot />
+      </span>
+      <template v-if="!noIcon">
+        <div v-if="icon" v-html="icon" class="nacelle-button-icon"></div>
+        <img v-else src="/nacelle-arrow-right.svg" alt="arrow-right" />
+      </template>
+    </button>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    buttonPath: {
+      type: String,
+      default: null
+    },
+    external: {
+      type: Boolean,
+      default: false
+    },
+    color: {
+      type: String,
+      default: 'primary'
+    },
+    icon: {
+      type: String,
+      default: null
+    },
+    noIcon: {
+      type: Boolean,
+      default: false
+    },
+    block: {
+      type: Boolean,
+      default: false
+    }
+  },
+  methods: {
+    clickHandler() {
+      if (this.buttonPath) {
+        window.open(this.buttonPath, '_blank')
+      } else {
+        this.$emit('click')
+      }
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.nacelle-button {
+  display: inline-block;
+  margin: 5px;
+
+  &.block {
+    display: flex;
+    justify-content: center;
+
+    button {
+      justify-content: center;
+      max-width: 600px;
+    }
+  }
+}
+button {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  justify-content: space-between;
+  text-decoration: none;
+  border: 2px solid #00baff;
+  border-radius: 5px;
+  padding: 10px 14px;
+  font-size: 16px;
+  width: 100%;
+  background: none;
+  cursor: pointer;
+  transition: all 0.3s;
+
+  span {
+    color: #ffffff;
+    font-family: 'HK Grotesk';
+    font-size: 16px;
+    font-weight: bold;
+    letter-spacing: 0.44px;
+    line-height: 20px;
+  }
+  img {
+    margin-left: 24px;
+    filter: invert(58%) sepia(35%) saturate(4655%) hue-rotate(162deg)
+      brightness(102%) contrast(104%); //Makes color #00BAFF (Blue)
+  }
+  &:hover {
+    background: #22346b;
+  }
+}
+.secondary {
+  border: 2px solid #fff;
+  img {
+    filter: brightness(0) invert(1);
+  }
+  &:hover {
+    border: 2px solid #00baff;
+    span {
+      color: #00baff;
+    }
+    img {
+      filter: invert(58%) sepia(35%) saturate(4655%) hue-rotate(162deg)
+        brightness(102%) contrast(104%); //Makes color #00BAFF (Blue)
+    }
+    background: #fff;
+  }
+}
+
+// mobile
+@media screen and (max-width: 1023px) {
+  button {
+    border-radius: 5px;
+    padding: 4px 8px;
+    span {
+      font-size: 16px;
+      letter-spacing: 0.25px;
+      line-height: 24px;
+    }
+    img {
+      width: 15px;
+    }
+  }
+}
+</style>

--- a/components/Page.vue
+++ b/components/Page.vue
@@ -9,6 +9,8 @@
 
     <slot name="bottom" />
     <Footer />
+
+    <Banner v-if="$page.bannerData" v-bind="$page.bannerData" />
   </main>
 </template>
 
@@ -16,9 +18,10 @@
 import PageEdit from '@parent-theme/components/PageEdit.vue';
 import PageNav from '@parent-theme/components/PageNav.vue';
 import Footer from './Footer.vue';
+import Banner from './Banner.vue';
 
 export default {
-  components: { PageEdit, PageNav, Footer },
+  components: { PageEdit, PageNav, Footer, Banner },
   props: ['sidebarItems']
 };
 </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nacelle/vuepress-theme-docs",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nacelle/vuepress-theme-docs",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Extension of vuepress default theme for Nacelle docs",
   "main": "index.js",
   "author": "Nacelle Dev Team",


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [[OS-82](https://nacelle.atlassian.net/browse/OS-82)] <!-- link to Jira or Github issue if one exists -->

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->
- This PR must be tested along with the latest PR for the OS-82 branch in [the nacelle-legacy-docs repo](https://github.com/getnacelle/nacelle-legacy-docs).
- Together these PRs check whether a banner has been defined on the homepage of the Nacelle website. If it is, it uses that information so the same banner can be presented on the docs website.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

This change updates the theme by copying the Banner and NacelleButton components from the Nacelle website. The Banner is displayed on the condition that a bannerData object is found in the page data (this data is found and passed when the docs website is built).

<details>
Banner appears after 1 second, remains when navigating to another page, slides down on close and stays closed while navigating to other pages
<img src="https://user-images.githubusercontent.com/15075999/132706242-7fddbb15-32a4-4bb7-899b-6a83216536cf.gif" alt="Banner appears after 1 second, remains when navigating to another page, slides down on close and stays closed while navigating to other pages](https://user-images.githubusercontent.com/15075999/132706242-7fddbb15-32a4-4bb7-899b-6a83216536cf.gif">
</details>

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to Test

[Local development instructions for theme](https://github.com/getnacelle/vuepress-theme-docs)
[Local development instructions for docs](https://github.com/getnacelle/nacelle-legacy-docs)

1. Pull the [theme repo](https://github.com/getnacelle/vuepress-theme-docs), switch to the OS-82 branch, and run `npm i`
2. Pull the [nacelle-legacy-docs](https://github.com/getnacelle/nacelle-legacy-docs) repo, switch to the OS-82 branch, add the .env (see link in that project's Readme or the private note in 1password), and run `npm i`
3. Follow the instructions in the docs project's Readme to link to the local directory that contains the theme.
4. After linked, run `npm run docs:dev` in the docs project.

### Testing checklist

* [ ] Tested on mobile
* [ ] Tested on multiple browsers
* [ ] Tested for accessibility
* [ ] Updated the `README.md` with documentation changes